### PR TITLE
[HtmlSanitizer] maxInputLength can be disabled

### DIFF
--- a/HtmlSanitizer.php
+++ b/HtmlSanitizer.php
@@ -62,8 +62,8 @@ final class HtmlSanitizer implements HtmlSanitizerInterface
         $this->domVisitors[$context] ??= $this->createDomVisitorForContext($context);
 
         // Prevent DOS attack induced by extremely long HTML strings
-        if (\strlen($input) > $this->config->getMaxInputLength()) {
-            $input = substr($input, 0, $this->config->getMaxInputLength());
+		if (null !== ($maxInputLength = $this->config->getMaxInputLength()) && \strlen($input) > $maxInputLength) {
+            $input = substr($input, 0, $maxInputLength);
         }
 
         // Only operate on valid UTF-8 strings. This is necessary to prevent cross

--- a/HtmlSanitizerConfig.php
+++ b/HtmlSanitizerConfig.php
@@ -92,7 +92,7 @@ class HtmlSanitizerConfig
      */
     private array $attributeSanitizers;
 
-    private int $maxInputLength = 20_000;
+    private ?int $maxInputLength = 20_000;
 
     public function __construct()
     {
@@ -407,7 +407,7 @@ class HtmlSanitizerConfig
         return $clone;
     }
 
-    public function withMaxInputLength(int $maxInputLength): static
+    public function withMaxInputLength(?int $maxInputLength): static
     {
         $clone = clone $this;
         $clone->maxInputLength = $maxInputLength;
@@ -415,7 +415,7 @@ class HtmlSanitizerConfig
         return $clone;
     }
 
-    public function getMaxInputLength(): int
+    public function getMaxInputLength(): ?int
     {
         return $this->maxInputLength;
     }


### PR DESCRIPTION
I have very long html because of base64 encoded images. Using `$config->withMaxInputLength(strlen($content))` is useless. Using `$config->withMaxInputLength(null)` to turn off the check is a better alternative.